### PR TITLE
Fix unit test failures

### DIFF
--- a/jestconfig.json
+++ b/jestconfig.json
@@ -13,6 +13,8 @@
     "REDIRECT_URL": "https://github.com/dangeredwolf/FixTweet",
     "EMBED_URL": "https://discord.gg/6CQTTTkGaH",
     "RELEASE_NAME": "fixtweet-test",
+    "DEPRECATED_DOMAIN_LIST": "pxtwitter.com,www.pxtwitter.com",
+    "DEPRECATED_DOMAIN_EPOCH": "1559320000000000000",
     "TEST": true
   },
   "testRegex": "/test/.*\\.test\\.ts$",


### PR DESCRIPTION
[352c970](https://github.com/dangeredwolf/FixTweet/commit/352c97042bc294be3cc69bb6668946b1dbed9195) introduced some new environment variables without adding them to the Jest config, which made the unit tests fail due to undefined globals.

This adds the new globals into the Jest config so the unit tests will now pass.