### PR TITLE
Fix ESLint parser errors in webpack config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,5 +9,8 @@
   "plugins": ["eslint-plugin-optimize-regex", "sonarjs"],
   "rules": {
     "sonarjs/cognitive-complexity": ["warn", 20]
+  },
+  "env": {
+    "es6": true
   }
 }


### PR DESCRIPTION
es6 wasn't turned on in the env